### PR TITLE
Add missing metadata for assembling code objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The supported code views are:
 4. Optimized AST
 5. Pseudo bytecode
 6. Optimized Pseudo bytecode
-7. Assembled Bytecode
+7. Assembled bytecode
 
 You can pre-load source from a file by running:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ I was able to get everything up by running the following commands:
 
 ```sh
 python3.13 -m venv env
+# or with uv
+uv venv env --python 3.13 --seed
 git clone https://github.com/grantjenks/py-tree-sitter-languages.git
 git clone https://github.com/iritkatriel/codoscope.git
 cd py-tree-sitter-languages/
@@ -44,7 +46,16 @@ env/bin/python codoscope/src/main.py
 
 Will start the application. You can press `e` to edit the code, and `CTRL+S` to go back
 to the inspector. You can enable different code views in the inspectors with the numbers
-from `1` to `7`. You can quit with `q`
+from `1` to `7`. You can quit with `q`.
+
+The supported code views are:
+1. Source
+2. Tokens
+3. AST
+4. Optimized AST
+5. Pseudo bytecode
+6. Optimized Pseudo bytecode
+7. Assembled Bytecode
 
 You can pre-load source from a file by running:
 
@@ -63,3 +74,5 @@ For showing the code of a python module you can run:
 ```sh
 env/bin/python codoscope/src/main.py -m package.module
 ```
+
+Once you run it, you can inspect parts of the source code and the corresponding code views by hovering over them. 

--- a/src/bytecode_widget.py
+++ b/src/bytecode_widget.py
@@ -59,9 +59,7 @@ if VERSION_3_13:
 
 
 def _complete_metadata(metadata, filename="myfile.py"):
-    """Complete metadata
-
-    Taken from: https://github.com/python/cpython/blob/5989095dfd08735525f2b615066bc3c231b09388/Lib/test/test_compiler_assemble.py#L13
+    Ensure that all fields of the metadata are set, as is done in  https://github.com/python/cpython/blob/5989095dfd08735525f2b615066bc3c231b09388/Lib/test/test_compiler_assemble.py#L13
     """
     if metadata is None:
         metadata = {}

--- a/src/bytecode_widget.py
+++ b/src/bytecode_widget.py
@@ -58,6 +58,26 @@ if VERSION_3_13:
             super().print_instruction(instr, mark_as_current=mark_as_current)
 
 
+def _complete_metadata(metadata, filename="myfile.py"):
+    """Complete metadata
+
+    Taken from: https://github.com/python/cpython/blob/5989095dfd08735525f2b615066bc3c231b09388/Lib/test/test_compiler_assemble.py#L13
+    """
+    if metadata is None:
+        metadata = {}
+    for key in ["name", "qualname"]:
+        metadata.setdefault(key, key)
+    for key in ["consts"]:
+        metadata.setdefault(key, [])
+    for key in ["names", "varnames", "cellvars", "freevars", "fasthidden"]:
+        metadata.setdefault(key, {})
+    for key in ["argcount", "posonlyargcount", "kwonlyargcount"]:
+        metadata.setdefault(key, 0)
+    metadata.setdefault("firstlineno", 1)
+    metadata.setdefault("filename", filename)
+    return metadata
+
+
 def _get_instructions(
     insts: Iterable[PseudoInstruction | dis.Instruction],
     arg_resolver: PseudoInstrsArgResolver,
@@ -151,11 +171,8 @@ class BytecodeWidget(BaseWidget):
                 insts = optimize_cfg(insts, co_consts, nlocals)
 
             if self.mode == "compiled":
-                # Assemble
                 metadata["consts"] = {name: i for i, name in enumerate(co_consts)}
-                from test.test_compiler_assemble import IsolatedAssembleTests
-
-                IsolatedAssembleTests().complete_metadata(metadata)
+                metadata = _complete_metadata(metadata)
                 co = assemble_code_object(filename, insts, metadata)
                 bytecode = dis.Bytecode(co)
                 output = list(bytecode)


### PR DESCRIPTION
Summary of changes:
- update README
- add a method to add metadata for assembling code object after optimizing CFG.

### Context

When I tried to run it, I was getting segmentation fault on generating assembled bytecode.
This was most likely due to metadata not being filled in and I added a method for the same, which fixed the issue.

### Background
I am working on understanding cpython internals - compilers stuff and I came across this work
in core-mentorship digest mailing thread. Lot of pieces in cpython internals is daunting but
this tool is beginner friendly to understand it. As next steps, I am interested in contribute
to this by:
- updating support to latest `textual`
- fixing the other issues.
