### PR TITLE
Keep Python 3.13 installs compatible by splitting Textual syntax extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ This requires:
 
 * CPython 3.13 (tested with 3.13.0b1)
 * dependencies in requirements.txt
-  * You will have to manually install `tree-sitter-languages` to have syntax
-    highlighting. See step-by-step instructions below
+* optional syntax highlighting for Textual mode:
+  * install `requirements-textual.txt`
+  * `tree-sitter-languages` support is currently unavailable on Python 3.13
 
 The code uses internal, undocumented CPython APIs. It is very likely to break in future
 CPython versions. When it does you get to keep both pieces.
@@ -36,6 +37,8 @@ cd py-tree-sitter-languages/
 ../env/bin/python setup.py install
 cd ../codoscope
 ../env/bin/pip install -r requirements.txt
+# Optional Textual syntax highlighting extras (Py<3.13):
+../env/bin/pip install -r requirements-textual.txt
 ```
 
 ## Usage

--- a/requirements-textual.txt
+++ b/requirements-textual.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+# Optional Textual syntax highlighting extra. tree-sitter-languages currently
+# does not publish wheels for Python 3.13.
+textual[syntax] ; python_version < "3.13"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 typing-extensions >= 4.12.0
 textual-dev
 textual
-textual[syntax]


### PR DESCRIPTION
## Summary
- remove `textual[syntax]` from the base `requirements.txt` so Python 3.13 installs do not fail on `tree-sitter-languages`
- add `requirements-textual.txt` for optional Textual syntax highlighting extras on supported Python versions
- update install docs in `README.md` to separate base install from optional Textual syntax extras

## Test plan
- [x] `python3 -m unittest tests/test_main.py`
- [ ] verify CI dependency installation on Python 3.13

Made with [Cursor](https://cursor.com)