### PR TITLE
Web: show real consts in pseudo bytecode (WASM-safe)

### DIFF
--- a/web/driver.py
+++ b/web/driver.py
@@ -130,6 +130,15 @@ def _co_consts_from_metadata(metadata):
     return [value for _idx, value in sorted((idx, value) for value, idx in consts.items())]
 
 
+def _merge_co_consts(metadata_consts, compiled_consts):
+    if metadata_consts is None:
+        return list(compiled_consts)
+    merged = list(metadata_consts)
+    if len(compiled_consts) > len(merged):
+        merged.extend(compiled_consts[len(merged) :])
+    return merged
+
+
 def _fit_co_consts(items, co_consts):
     max_arg = _max_const_arg(items)
     if max_arg < 0:
@@ -154,9 +163,7 @@ def _instruction_items(insts):
 
 def view_pseudo(code: str, *, optimize: bool = False) -> str:
     insts, metadata = compiler_codegen(ast.parse(code, optimize=1), "<source>", 0)
-    co_consts = _co_consts_from_metadata(metadata)
-    if co_consts is None:
-        co_consts = _compiled_co_consts(code)
+    co_consts = _merge_co_consts(_co_consts_from_metadata(metadata), _compiled_co_consts(code))
     # On some newer WASM builds (e.g. CPython 3.15 snapshots), optimize_cfg can
     # trap at runtime with low-level wasm errors. Prefer a stable pseudo view
     # there instead of crashing the whole worker process.

--- a/web/driver.py
+++ b/web/driver.py
@@ -126,16 +126,24 @@ def _co_consts_from_metadata(metadata):
     consts = metadata.get("consts")
     if not isinstance(consts, dict) or not consts:
         return None
-    # compiler metadata stores const->index; disassembly expects a dense list.
-    return [value for _idx, value in sorted((idx, value) for value, idx in consts.items())]
+    # compiler metadata stores const->index and indices may be sparse.
+    max_idx = max(consts.values())
+    resolved = [_ConstPlaceholder(i) for i in range(max_idx + 1)]
+    for value, idx in consts.items():
+        resolved[idx] = value
+    return resolved
 
 
 def _merge_co_consts(metadata_consts, compiled_consts):
     if metadata_consts is None:
         return list(compiled_consts)
     merged = list(metadata_consts)
-    if len(compiled_consts) > len(merged):
-        merged.extend(compiled_consts[len(merged) :])
+    limit = max(len(merged), len(compiled_consts))
+    if len(merged) < limit:
+        merged.extend(_ConstPlaceholder(i) for i in range(len(merged), limit))
+    for i, value in enumerate(compiled_consts):
+        if isinstance(merged[i], _ConstPlaceholder):
+            merged[i] = value
     return merged
 
 

--- a/web/driver.py
+++ b/web/driver.py
@@ -150,12 +150,12 @@ def _merge_co_consts(metadata_consts, compiled_consts):
 def _fit_co_consts(items, co_consts):
     max_arg = _max_const_arg(items)
     if max_arg < 0:
-        return co_consts
+        return [None if isinstance(v, _ConstPlaceholder) else v for v in co_consts]
     if len(co_consts) > max_arg:
-        return co_consts
+        return [None if isinstance(v, _ConstPlaceholder) else v for v in co_consts]
     fitted = list(co_consts)
-    fitted.extend(_ConstPlaceholder(i) for i in range(len(fitted), max_arg + 1))
-    return fitted
+    fitted.extend(None for _ in range(len(fitted), max_arg + 1))
+    return [None if isinstance(v, _ConstPlaceholder) else v for v in fitted]
 
 
 def _compiled_co_consts(code: str):

--- a/web/driver.py
+++ b/web/driver.py
@@ -104,6 +104,11 @@ class _ConstPlaceholder:
         return f"<const#{self.idx}>"
 
 
+class _InternalConstPlaceholder:
+    def __repr__(self):
+        return "<internal const>"
+
+
 def _max_const_arg(items):
     max_arg = -1
     for inst in items:
@@ -158,6 +163,46 @@ def _fit_co_consts(items, co_consts):
     return fitted
 
 
+def _is_annotations_placeholder(inst) -> bool:
+    if isinstance(inst, dis.Instruction):
+        return inst.opname == "ANNOTATIONS_PLACEHOLDER"
+    return dis._all_opname[inst[0]] == "ANNOTATIONS_PLACEHOLDER"
+
+
+def _load_const_arg(inst):
+    if isinstance(inst, dis.Instruction):
+        if inst.opcode in dis.hasconst:
+            return inst.arg
+        return None
+    op, arg = inst[0], inst[1]
+    if op in dis.hasconst:
+        return arg
+    return None
+
+
+def _apply_annotations_const_workaround(items, co_consts):
+    """3.15+ pseudo code may use an internal const slot for annotations.
+
+    Insert an explicit placeholder for that internal slot so subsequent
+    LOAD_CONST values align with user-visible constants.
+    """
+    for i, inst in enumerate(items):
+        if not _is_annotations_placeholder(inst):
+            continue
+        for nxt in items[i + 1 :]:
+            const_arg = _load_const_arg(nxt)
+            if const_arg is None:
+                continue
+            adjusted = list(co_consts)
+            insert_at = const_arg
+            if insert_at > len(adjusted):
+                adjusted.extend(_ConstPlaceholder(k) for k in range(len(adjusted), insert_at))
+            adjusted.insert(insert_at, _InternalConstPlaceholder())
+            return adjusted
+        break
+    return co_consts
+
+
 def _compiled_co_consts(code: str):
     # Fallback source for const values when compiler metadata omits "consts".
     return list(compile(code, "<source>", "exec", optimize=1).co_consts)
@@ -178,7 +223,8 @@ def view_pseudo(code: str, *, optimize: bool = False) -> str:
     if optimize and sys.version_info < (3, 15):
         insts = optimize_cfg(insts, co_consts, 0)
     items = _instruction_items(insts)
-    return _disassemble(items, _fit_co_consts(items, co_consts))
+    adjusted_consts = _apply_annotations_const_workaround(items, co_consts)
+    return _disassemble(items, _fit_co_consts(items, adjusted_consts))
 
 
 def view_compiled(code: str) -> str:

--- a/web/driver.py
+++ b/web/driver.py
@@ -150,12 +150,12 @@ def _merge_co_consts(metadata_consts, compiled_consts):
 def _fit_co_consts(items, co_consts):
     max_arg = _max_const_arg(items)
     if max_arg < 0:
-        return [None if isinstance(v, _ConstPlaceholder) else v for v in co_consts]
+        return co_consts
     if len(co_consts) > max_arg:
-        return [None if isinstance(v, _ConstPlaceholder) else v for v in co_consts]
+        return co_consts
     fitted = list(co_consts)
-    fitted.extend(None for _ in range(len(fitted), max_arg + 1))
-    return [None if isinstance(v, _ConstPlaceholder) else v for v in fitted]
+    fitted.extend(_ConstPlaceholder(i) for i in range(len(fitted), max_arg + 1))
+    return fitted
 
 
 def _compiled_co_consts(code: str):

--- a/web/driver.py
+++ b/web/driver.py
@@ -120,18 +120,50 @@ def _placeholder_consts(items):
     return [_ConstPlaceholder(i) for i in range(_max_const_arg(items) + 1)]
 
 
+def _co_consts_from_metadata(metadata):
+    if not metadata:
+        return None
+    consts = metadata.get("consts")
+    if not isinstance(consts, dict) or not consts:
+        return None
+    # compiler metadata stores const->index; disassembly expects a dense list.
+    return [value for _idx, value in sorted((idx, value) for value, idx in consts.items())]
+
+
+def _fit_co_consts(items, co_consts):
+    max_arg = _max_const_arg(items)
+    if max_arg < 0:
+        return co_consts
+    if len(co_consts) > max_arg:
+        return co_consts
+    fitted = list(co_consts)
+    fitted.extend(_ConstPlaceholder(i) for i in range(len(fitted), max_arg + 1))
+    return fitted
+
+
+def _compiled_co_consts(code: str):
+    # Fallback source for const values when compiler metadata omits "consts".
+    return list(compile(code, "<source>", "exec", optimize=1).co_consts)
+
+
+def _instruction_items(insts):
+    if hasattr(insts, "get_instructions"):
+        return list(insts.get_instructions())
+    return list(insts)
+
+
 def view_pseudo(code: str, *, optimize: bool = False) -> str:
-    # CPython main's compiler_codegen() no longer puts "consts" in the metadata
-    # dict, and there is no Python-visible API to read them off the instruction
-    # sequence. Use opaque placeholders sized to the largest LOAD_CONST arg so
-    # the optimizer and dis.ArgResolver don't crash; const args render as
-    # <const#N> rather than their real values.
-    insts, _metadata = compiler_codegen(ast.parse(code, optimize=1), "<source>", 0)
-    if optimize:
-        placeholders = _placeholder_consts(list(insts.get_instructions()))
-        insts = optimize_cfg(insts, placeholders, 0)
-    items = list(insts.get_instructions())
-    return _disassemble(items, _placeholder_consts(items))
+    insts, metadata = compiler_codegen(ast.parse(code, optimize=1), "<source>", 0)
+    co_consts = _co_consts_from_metadata(metadata)
+    if co_consts is None:
+        co_consts = _compiled_co_consts(code)
+    # On some newer WASM builds (e.g. CPython 3.15 snapshots), optimize_cfg can
+    # trap at runtime with low-level wasm errors. Prefer a stable pseudo view
+    # there instead of crashing the whole worker process.
+    if optimize and sys.version_info < (3, 15):
+        insts = optimize_cfg(insts, co_consts, 0)
+    items = _instruction_items(insts)
+    return _disassemble(items, _fit_co_consts(items, co_consts))
 
 
 def view_compiled(code: str) -> str:


### PR DESCRIPTION
## Summary
- Resolve `LOAD_CONST` values in the browser pseudo bytecode views using compiler metadata, with fallbacks when metadata is sparse.
- Skip `optimize_cfg` on CPython 3.15+ in the web driver to avoid WASM runtime traps while keeping pseudo output useful.

## Test plan
- [x] `python3 -m py_compile web/driver.py`
- [ ] Manual: local `_site` + Run in browser (pseudo + optimized pseudo panels)

Made with [Cursor](https://cursor.com)