### PR TITLE
Web: Makefile serve targets and worker startup diagnostics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,27 @@
 PYTHON ?= python3.13
+WEB_PORT ?= 8000
 
-.PHONY: test
+.PHONY: test web web-sync web-kill web-restart
 test:
 	$(PYTHON) -m unittest discover -s tests -v
+
+web-sync:
+	@test -d _site || (echo "_site/ not found. Build/stage the web site first." && exit 1)
+	cp web/index.html _site/index.html
+	cp web/driver.py _site/driver.py
+	cp web/python.worker.mjs _site/python.worker.mjs
+
+web: web-sync
+	@echo "Serving codoscope web UI at http://localhost:$(WEB_PORT)"
+	cd _site && $(PYTHON) -m http.server $(WEB_PORT)
+
+web-kill:
+	@pids=$$(lsof -t -iTCP:$(WEB_PORT) -sTCP:LISTEN 2>/dev/null); \
+	if [ -z "$$pids" ]; then \
+		echo "No web server listening on port $(WEB_PORT)"; \
+	else \
+		echo "Stopping process(es) on port $(WEB_PORT): $$pids"; \
+		kill $$pids; \
+	fi
+
+web-restart: web-kill web

--- a/web/index.html
+++ b/web/index.html
@@ -212,6 +212,13 @@ print(f(42))</div>
                 document.querySelector(`.panel[data-view="${view}"] .content`).textContent = text;
             };
 
+            const showError = (text) => {
+                const short = String(text).split("\n")[0];
+                status.textContent = `error: ${short}`;
+                pyver.textContent = "failed to start CPython (WASM)";
+                for (const v of VIEWS) setPanelContent(v, String(text));
+            };
+
             const clearAllPanels = (placeholder) => {
                 for (const v of VIEWS) setPanelContent(v, placeholder);
             };
@@ -222,19 +229,71 @@ print(f(42))</div>
                 clearAllPanels("…");
 
                 const stdout = [];
+                const stderr = [];
+                let finished = false;
                 const worker = new Worker("./python.worker.mjs", { type: "module" });
+                const startedAt = Date.now();
+                const watchdog = setInterval(() => {
+                    if (finished) {
+                        clearInterval(watchdog);
+                        return;
+                    }
+                    const seconds = Math.floor((Date.now() - startedAt) / 1000);
+                    status.textContent = `compiling… (${seconds}s, initializing WASM)`;
+                }, 1000);
                 worker.onmessage = (e) => {
                     const d = e.data;
                     if (d.type === "stdout") {
                         stdout.push(d.stdout);
-                    } else if (d.type === "finished") {
+                    } else if (d.type === "stderr") {
+                        stderr.push(d.stderr);
+                    } else if (d.type === "worker-error") {
+                        finished = true;
+                        clearInterval(watchdog);
                         worker.terminate();
-                        const result = JSON.parse(String.fromCharCode(...stdout));
-                        pyver.textContent = `CPython ${result.python_version} (WASM)`;
-                        for (const v of VIEWS) setPanelContent(v, result[v]);
-                        status.textContent = "";
+                        showError(`Worker initialization failed: ${d.error || "unknown error"}`);
+                        runBtn.disabled = false;
+                    } else if (d.type === "ready") {
+                        status.textContent = "runtime ready, running…";
+                    } else if (d.type === "finished") {
+                        finished = true;
+                        clearInterval(watchdog);
+                        worker.terminate();
+                        try {
+                            const result = JSON.parse(String.fromCharCode(...stdout));
+                            pyver.textContent = `CPython ${result.python_version} (WASM)`;
+                            for (const v of VIEWS) setPanelContent(v, result[v] ?? "");
+                            status.textContent = "";
+                        } catch (err) {
+                            const errText = [
+                                "Failed to parse worker output.",
+                                "",
+                                `Error: ${String(err)}`,
+                                "",
+                                "stderr:",
+                                String.fromCharCode(...stderr),
+                                "",
+                                "stdout:",
+                                String.fromCharCode(...stdout),
+                            ].join("\n");
+                            showError(errText);
+                        }
                         runBtn.disabled = false;
                     }
+                };
+                worker.onerror = (e) => {
+                    finished = true;
+                    clearInterval(watchdog);
+                    const errText = `Worker error: ${e.message || "unknown error"}`;
+                    showError(errText);
+                    runBtn.disabled = false;
+                };
+                worker.onmessageerror = () => {
+                    finished = true;
+                    clearInterval(watchdog);
+                    const errText = "Worker message decoding error";
+                    showError(errText);
+                    runBtn.disabled = false;
                 };
 
                 worker.postMessage({
@@ -255,7 +314,13 @@ print(f(42))</div>
             runBtn.addEventListener("click", run);
 
             window.addEventListener("load", async () => {
-                driverSource = await fetch("driver.py").then((r) => r.text());
+                try {
+                    driverSource = await fetch("driver.py", { cache: "no-store" }).then((r) => r.text());
+                } catch (err) {
+                    const errText = `Failed to load driver.py: ${String(err)}`;
+                    showError(errText);
+                    return;
+                }
                 runBtn.disabled = false;
                 run();
             });

--- a/web/python.worker.mjs
+++ b/web/python.worker.mjs
@@ -1,0 +1,124 @@
+import createEmscriptenModule from "./python.mjs";
+
+class StdinBuffer {
+  constructor() {
+    this.sab = new SharedArrayBuffer(128 * Int32Array.BYTES_PER_ELEMENT);
+    this.buffer = new Int32Array(this.sab);
+    this.readIndex = 1;
+    this.numberOfCharacters = 0;
+    this.sentNull = true;
+  }
+
+  prompt() {
+    this.readIndex = 1;
+    Atomics.store(this.buffer, 0, -1);
+    postMessage({
+      type: "stdin",
+      buffer: this.sab,
+    });
+    Atomics.wait(this.buffer, 0, -1);
+    this.numberOfCharacters = this.buffer[0];
+  }
+
+  stdin = () => {
+    while (this.numberOfCharacters + 1 === this.readIndex) {
+      if (!this.sentNull) {
+        // Must return null once to indicate we're done for now.
+        this.sentNull = true;
+        return null;
+      }
+      this.sentNull = false;
+      // Prompt will reset this.readIndex to 1
+      this.prompt();
+    }
+    const char = this.buffer[this.readIndex];
+    this.readIndex += 1;
+    return char;
+  };
+}
+
+const stdout = (charCode) => {
+  if (charCode) {
+    postMessage({
+      type: "stdout",
+      stdout: charCode,
+    });
+  } else {
+    console.log(typeof charCode, charCode);
+  }
+};
+
+const stderr = (charCode) => {
+  if (charCode) {
+    postMessage({
+      type: "stderr",
+      stderr: charCode,
+    });
+  } else {
+    console.log(typeof charCode, charCode);
+  }
+};
+
+const stdinBuffer = new StdinBuffer();
+
+const emscriptenSettings = {
+  noInitialRun: true,
+  stdin: stdinBuffer.stdin,
+  stdout: stdout,
+  stderr: stderr,
+  onRuntimeInitialized: () => {
+    postMessage({ type: "ready", stdinBuffer: stdinBuffer.sab });
+  },
+  async preRun(Module) {
+    const versionInt = Module.HEAPU32[Module._Py_Version >>> 2];
+    const major = (versionInt >>> 24) & 0xff;
+    const minor = (versionInt >>> 16) & 0xff;
+    // Prevent complaints about not finding exec-prefix by making a lib-dynload directory
+    Module.FS.mkdirTree(`/lib/python${major}.${minor}/lib-dynload/`);
+    const depName = "install-stdlib";
+    const stdlibName = `python${major}.${minor}.zip`;
+    Module.addRunDependency(depName);
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 30000);
+      const resp = await fetch(stdlibName, { signal: controller.signal });
+      clearTimeout(timeoutId);
+      if (!resp.ok) {
+        throw new Error(`failed to fetch ${stdlibName}: HTTP ${resp.status}`);
+      }
+      const stdlibBuffer = await resp.arrayBuffer();
+      Module.FS.writeFile(
+        `/lib/python${major}${minor}.zip`,
+        new Uint8Array(stdlibBuffer),
+        { canOwn: true },
+      );
+    } finally {
+      Module.removeRunDependency(depName);
+    }
+  },
+};
+
+const modulePromise = createEmscriptenModule(emscriptenSettings);
+
+onmessage = async (event) => {
+  if (event.data.type === "run") {
+    try {
+      const Module = await modulePromise;
+      if (event.data.files) {
+        for (const [filename, contents] of Object.entries(event.data.files)) {
+          Module.FS.writeFile(filename, contents);
+        }
+      }
+      const ret = Module.callMain(event.data.args);
+      postMessage({
+        type: "finished",
+        returnCode: ret,
+      });
+    } catch (error) {
+      postMessage({
+        type: "worker-error",
+        error: String(error),
+      });
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- Add `make web-sync`, `web`, `web-kill`, and `web-restart` to copy `web/` assets into `_site` and serve locally on a configurable `WEB_PORT`.
- Improve `web/index.html` worker handling: stderr capture, parse errors, worker errors, and init progress text.
- Track `web/python.worker.mjs` in-repo and sync it with `_site` so local edits match what the browser loads.

## Test plan
- [ ] `make web-restart WEB_PORT=8000` and verify UI loads from `_site`
- [ ] Confirm `web-sync` copies `index.html`, `driver.py`, and `python.worker.mjs`

Made with [Cursor](https://cursor.com)