### PR TITLE
Add GitHub Pages preview deploys for pull requests

### DIFF
--- a/.github/workflows/cpython-wasm.yml
+++ b/.github/workflows/cpython-wasm.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
   workflow_dispatch:
     inputs:
       cpython_ref:
@@ -37,6 +44,7 @@ jobs:
       node_version: ${{ steps.versions.outputs.node_version }}
       cpython_ref: ${{ steps.ref.outputs.cpython_ref }}
       deploy_channel: ${{ steps.channel.outputs.deploy_channel }}
+      deploy_destination: ${{ steps.channel.outputs.deploy_destination }}
     steps:
       - name: "Resolve cpython ref"
         id: ref
@@ -50,13 +58,24 @@ jobs:
         env:
           CHANNEL_INPUT: ${{ inputs.deploy_channel }}
           EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ "$EVENT_NAME" = "push" ]; then
             channel="dev"
+            destination="dev"
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            channel="preview"
+            destination="pr-${PR_NUMBER}"
           else
             channel="${CHANNEL_INPUT:-stable}"
+            if [ "$channel" = "dev" ]; then
+              destination="dev"
+            else
+              destination=""
+            fi
           fi
           echo "deploy_channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "deploy_destination=$destination" >> "$GITHUB_OUTPUT"
       - name: "Checkout cpython @ ${{ steps.ref.outputs.cpython_ref }}"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -159,10 +178,13 @@ jobs:
     name: "Publish site"
     needs: [get-emscripten-version, build]
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
+      pull-requests: write
     env:
       DEPLOY_CHANNEL: ${{ needs.get-emscripten-version.outputs.deploy_channel }}
+      DEPLOY_DESTINATION: ${{ needs.get-emscripten-version.outputs.deploy_destination }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -187,6 +209,18 @@ jobs:
           force_orphan: false
           commit_message: "Publish dev CPython WASM build (cpython@${{ needs.get-emscripten-version.outputs.cpython_ref || 'main' }})"
 
+      - name: "Deploy PR preview site"
+        if: env.DEPLOY_CHANNEL == 'preview'
+        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: gh-pages
+          destination_dir: ${{ env.DEPLOY_DESTINATION }}
+          keep_files: true
+          force_orphan: false
+          commit_message: "Publish PR preview #${{ github.event.pull_request.number }}"
+
       - name: "Deploy stable site to gh-pages root"
         if: env.DEPLOY_CHANNEL == 'stable'
         uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
@@ -197,3 +231,18 @@ jobs:
           keep_files: true
           force_orphan: false
           commit_message: "Publish stable CPython WASM build (cpython@${{ needs.get-emscripten-version.outputs.cpython_ref || 'main' }})"
+
+      - name: "Comment PR preview URL"
+        if: env.DEPLOY_CHANNEL == 'preview'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const previewUrl = `https://${owner}.github.io/${repo}/${process.env.DEPLOY_DESTINATION}/`;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: context.issue.number,
+              body: `Preview deployed: ${previewUrl}`,
+            });

--- a/.github/workflows/cpython-wasm.yml
+++ b/.github/workflows/cpython-wasm.yml
@@ -20,11 +20,10 @@ on:
       deploy_channel:
         required: true
         default: "stable"
-        description: "Where to publish the site"
+        description: "Where to publish the site (manual runs)"
         type: choice
         options:
           - stable
-          - dev
 # Maybe rebuild evrery now and again?
 #  schedule:
 #    - cron: ""
@@ -61,18 +60,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [ "$EVENT_NAME" = "push" ]; then
-            channel="dev"
-            destination="dev"
+            channel="stable"
+            destination=""
           elif [ "$EVENT_NAME" = "pull_request" ]; then
             channel="preview"
             destination="pr-${PR_NUMBER}"
           else
             channel="${CHANNEL_INPUT:-stable}"
-            if [ "$channel" = "dev" ]; then
-              destination="dev"
-            else
-              destination=""
-            fi
+            destination=""
           fi
           echo "deploy_channel=$channel" >> "$GITHUB_OUTPUT"
           echo "deploy_destination=$destination" >> "$GITHUB_OUTPUT"
@@ -197,18 +192,6 @@ jobs:
           name: site
           path: site
 
-      - name: "Deploy dev site to gh-pages/dev"
-        if: env.DEPLOY_CHANNEL == 'dev'
-        uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./site
-          publish_branch: gh-pages
-          destination_dir: dev
-          keep_files: true
-          force_orphan: false
-          commit_message: "Publish dev CPython WASM build (cpython@${{ needs.get-emscripten-version.outputs.cpython_ref || 'main' }})"
-
       - name: "Deploy PR preview site"
         if: env.DEPLOY_CHANNEL == 'preview'
         uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
@@ -230,7 +213,7 @@ jobs:
           publish_branch: gh-pages
           keep_files: true
           force_orphan: false
-          commit_message: "Publish stable CPython WASM build (cpython@${{ needs.get-emscripten-version.outputs.cpython_ref || 'main' }})"
+          commit_message: "Publish site from main (cpython@${{ needs.get-emscripten-version.outputs.cpython_ref || 'main' }})"
 
       - name: "Comment PR preview URL"
         if: env.DEPLOY_CHANNEL == 'preview'


### PR DESCRIPTION
## Summary
- run the WASM Pages workflow on pull requests to `main`
- publish each PR preview under `gh-pages/pr-<number>/`
- comment the preview URL on the PR after deploy
- skip preview deploys for forked PRs where token permissions can't publish Pages

## Test plan
- [ ] open or update a PR from this repository and confirm a preview deploy comment appears
- [ ] verify preview URL loads: `https://iritkatriel.github.io/codoscope/pr-<number>/`

Made with [Cursor](https://cursor.com)