### PR TITLE
Fix bytecode widget for list-based compiler output

### DIFF
--- a/src/bytecode_widget.py
+++ b/src/bytecode_widget.py
@@ -108,6 +108,15 @@ def _get_instructions(
         )
 
 
+def _instruction_items(
+    insts: Any,
+) -> list[PseudoInstruction | dis.Instruction]:
+    """Support both CFG objects and plain instruction lists."""
+    if hasattr(insts, "get_instructions"):
+        return list(insts.get_instructions())
+    return list(insts)
+
+
 def _disassemble(
     insts: Sequence[PseudoInstruction | dis.Instruction],
     co_consts: Sequence[object],
@@ -174,7 +183,7 @@ class BytecodeWidget(BaseWidget):
                 bytecode = dis.Bytecode(co)
                 output = list(bytecode)
             else:
-                output = insts.get_instructions()
+                output = _instruction_items(insts)
 
             self.update(_disassemble(output, co_consts, f"<{self.mode} bytecode>"))
         else:


### PR DESCRIPTION
## Summary
- add a compatibility helper in `src/bytecode_widget.py` that accepts either `get_instructions()` objects or plain instruction lists
- use that helper for pseudo/optimized bytecode rendering to avoid runtime crashes when `compiler_codegen` returns a list

## Test plan
- [x] `python3 -m py_compile src/bytecode_widget.py`
- [ ] run `python src/main.py` under Python 3.13 and confirm pseudo panes render without `AttributeError`

Made with [Cursor](https://cursor.com)